### PR TITLE
fix(openfga): allow service and deployment annotations

### DIFF
--- a/charts/openfga/templates/deployment.yaml
+++ b/charts/openfga/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "openfga.fullname" . }}
   labels:
     {{- include "openfga.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/openfga/templates/service.yaml
+++ b/charts/openfga/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "openfga.fullname" . }}
   labels:
     {{- include "openfga.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/openfga/values.schema.json
+++ b/charts/openfga/values.schema.json
@@ -313,6 +313,40 @@
         "allowEvaluating1_0Models": {
             "type": ["boolean", "null"],
             "description": "allow calling Check, Expand, ListObjects, Write Assertions with models that have 1.0 schema version"
+        },
+        "annotations": {
+            "type": "object",
+            "description": "Map of annotations to add to the deployment's manifest",
+            "additionalProperties": { "type": "string" },
+            "default": { }
+        },
+        "podAnnotations": {
+            "type": "object",
+            "description": "Map of annotations to add to the pods' manifest",
+            "additionalProperties": { "type": "string" },
+            "default": { }
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "description": "Map of annotations to add to the service's manifest",
+                    "additionalProperties": { "type": "string" },
+                    "default": { }
+                }
+            }
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "description": "Map of annotations to add to the ingress' manifest",
+                    "additionalProperties": { "type": "string" },
+                    "default": { }
+                }
+            }
         }
     }
 }

--- a/charts/openfga/values.yaml
+++ b/charts/openfga/values.yaml
@@ -19,6 +19,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+annotations: {}
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -33,6 +35,7 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
+  annotations: {}
   type: ClusterIP
   port: 8080
 


### PR DESCRIPTION
To allow us to define the annotations locally in our release.